### PR TITLE
Correct Contrast Init

### DIFF
--- a/monochromeoled.go
+++ b/monochromeoled.go
@@ -78,7 +78,7 @@ func (o *OLED) Init() (err error) {
 	if o.h == 64 {
 		err = o.dev.Write([]byte{
 			0xda, 0x12,
-			0x81, 0x9f, // set contrast
+			0x81, 0x7f, // set contrast
 		})
 	}
 	err = o.dev.Write([]byte{


### PR DESCRIPTION
Following another whitepaper and my own configuration testing, I believe you have your contrast values off. Where you have 0x9F but should be 0x7F.
See page 28 of the SSD1306 datasheet https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf which details the contrast reset to be 0x7F and is referenced in the following whitepaper. http://robotcantalk.blogspot.in/2015/03/interfacing-arduino-with-ssd1306-driven.html 